### PR TITLE
Feature/allow inline badges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ build
 .idea
 *.iml
 out
+.project
+.metadata
+bin/
+.classpath
+.settings/

--- a/README.md
+++ b/README.md
@@ -66,5 +66,4 @@ jacocoBadgeGenSetting {
 
 ### Coverage Badge Type
 Jacoco gives us 6 coverage metrics in its test report, namely `INSTRUCTION`, `BRANCH`, `LINE`, 
-`COMPLEXITY`, `METHOD` and `CLASS`. Your badge link should be place **within a new line** and 
-the `alt` part should be **one of the 6 values** so that this plugin can detect them.
+`COMPLEXITY`, `METHOD` and `CLASS`. The `alt` part should be **one of the 6 values** so that this plugin can detect them.

--- a/src/main/java/com/github/dawnwords/jacoco/badge/JacocoBadgePlugin.java
+++ b/src/main/java/com/github/dawnwords/jacoco/badge/JacocoBadgePlugin.java
@@ -3,7 +3,6 @@ package com.github.dawnwords.jacoco.badge;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
-@SuppressWarnings("unused")
 public class JacocoBadgePlugin implements Plugin<Project> {
 
   @Override

--- a/src/main/java/com/github/dawnwords/jacoco/badge/ReadMeUpdater.java
+++ b/src/main/java/com/github/dawnwords/jacoco/badge/ReadMeUpdater.java
@@ -13,7 +13,7 @@ class ReadMeUpdater {
   private JacocoBadgeGenerateSetting setting;
   private JacocoResultParser parser;
 
-  private static final Pattern BADGE_PATTERN = Pattern.compile("^!\\[([^]]+)]\\(([^)]+)\\)$");
+  private static final Pattern BADGE_PATTERN = Pattern.compile("!\\[([^]]+)]\\(([^)]+)\\)");
 
   ReadMeUpdater(JacocoBadgeGenerateSetting setting) {
     this(setting, new JacocoResultParser(setting));
@@ -32,15 +32,17 @@ class ReadMeUpdater {
     final Path readmePath = Paths.get(setting.getReadmePath());
     Files.write(readmePath, Files.readAllLines(readmePath).stream()
         .map(l -> {
+          final StringBuffer stringBuffer = new StringBuffer();
           Matcher matcher = BADGE_PATTERN.matcher(l);
-          if (matcher.find()) {
+          while (matcher.find()) {
             String type = matcher.group(1);
             JacocoBadgePercentageResult result = results.get(type);
             if (result != null) {
-              return matcher.replaceFirst(String.format("![$1](%s)", result.badgeUrl()));
+                matcher.appendReplacement(stringBuffer, String.format("![$1](%s)", result.badgeUrl()));
             }
           }
-          return l;
+          matcher.appendTail(stringBuffer);
+          return stringBuffer.toString();
         })
         .collect(Collectors.toList()));
   }

--- a/src/test/java/com/github/dawnwords/jacoco/badge/JacocoBadgeComplexityResultTest.java
+++ b/src/test/java/com/github/dawnwords/jacoco/badge/JacocoBadgeComplexityResultTest.java
@@ -3,6 +3,9 @@ package com.github.dawnwords.jacoco.badge;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
+
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
@@ -26,15 +29,19 @@ public class JacocoBadgeComplexityResultTest {
 
   @DataProvider
   private Object[][] test() {
+	
+	final char decimalSeparatorChar = new DecimalFormatSymbols(Locale.getDefault()).getDecimalSeparator();  
+	final String decimalSeparator = new String(new char[]{decimalSeparatorChar});
+	  
     return new Object[][]{
-        new Object[]{120, 0, 60, "COMPLEXITY:2.00",
-            "https://img.shields.io/badge/complexity-2.00-brightgreen.svg"},
-        new Object[]{120, 0, 8, "COMPLEXITY:15.00",
-            "https://img.shields.io/badge/complexity-15.00-yellow.svg"},
-        new Object[]{120, 0, 4, "COMPLEXITY:30.00",
-            "https://img.shields.io/badge/complexity-30.00-orange.svg"},
-        new Object[]{120, 0, 2, "COMPLEXITY:60.00",
-            "https://img.shields.io/badge/complexity-60.00-red.svg"},
+        new Object[]{120, 0, 60, "COMPLEXITY:2" + decimalSeparator + "00",
+            "https://img.shields.io/badge/complexity-2" + decimalSeparator + "00-brightgreen.svg"},
+        new Object[]{120, 0, 8, "COMPLEXITY:15" + decimalSeparator + "00",
+            "https://img.shields.io/badge/complexity-15" + decimalSeparator + "00-yellow.svg"},
+        new Object[]{120, 0, 4, "COMPLEXITY:30" + decimalSeparator + "00",
+            "https://img.shields.io/badge/complexity-30" + decimalSeparator + "00-orange.svg"},
+        new Object[]{120, 0, 2, "COMPLEXITY:60" + decimalSeparator + "00",
+            "https://img.shields.io/badge/complexity-60" + decimalSeparator + "00-red.svg"},
     };
   }
 

--- a/src/test/java/com/github/dawnwords/jacoco/badge/JacocoBadgeComplexityResultTest.java
+++ b/src/test/java/com/github/dawnwords/jacoco/badge/JacocoBadgeComplexityResultTest.java
@@ -1,16 +1,15 @@
 package com.github.dawnwords.jacoco.badge;
 
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
-import com.github.dawnwords.jacoco.badge.JacocoBadgePercentageResult.Type;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
+
+import com.github.dawnwords.jacoco.badge.JacocoBadgePercentageResult.Type;
 
 public class JacocoBadgeComplexityResultTest {
 

--- a/src/test/java/com/github/dawnwords/jacoco/badge/JacocoResultParserTest.java
+++ b/src/test/java/com/github/dawnwords/jacoco/badge/JacocoResultParserTest.java
@@ -4,6 +4,8 @@ import static org.testng.Assert.assertEquals;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.gradle.internal.impldep.com.google.common.collect.ImmutableMap;
@@ -13,6 +15,9 @@ public class JacocoResultParserTest {
 
   @Test
   public void testGetJacocoResults() throws Exception {
+	final char decimalSeparatorChar = new DecimalFormatSymbols(Locale.getDefault()).getDecimalSeparator();  
+	final String decimalSeparator = new String(new char[]{decimalSeparatorChar});
+		
     Path sampleReport = Files.createTempFile("testGetJacocoResults", "sample-jacoco-report.xml");
     IOUtils.copy(JacocoResultParserTest.class.getClassLoader()
         .getResourceAsStream("sample-jacoco-report.xml"), Files.newOutputStream(sampleReport));
@@ -25,7 +30,7 @@ public class JacocoResultParserTest {
     assertEquals(result.get("BRANCH").toString(), "BRANCH:100%");
     assertEquals(result.get("INSTRUCTION").toString(), "INSTRUCTION:100%");
     assertEquals(result.get("LINE").toString(), "LINE:100%");
-    assertEquals(result.get("COMPLEXITY").toString(), "COMPLEXITY:10.00");
+    assertEquals(result.get("COMPLEXITY").toString(), "COMPLEXITY:10" + decimalSeparator + "00");
     assertEquals(result.get("METHOD").toString(), "METHOD:100%");
     assertEquals(result.get("CLASS").toString(), "CLASS:100%");
   }

--- a/src/test/java/com/github/dawnwords/jacoco/badge/ReadMeUpdaterTest.java
+++ b/src/test/java/com/github/dawnwords/jacoco/badge/ReadMeUpdaterTest.java
@@ -1,12 +1,14 @@
 package com.github.dawnwords.jacoco.badge;
 
-import static com.github.dawnwords.jacoco.badge.JacocoBadgePercentageResult.Type.*;
+import static com.github.dawnwords.jacoco.badge.JacocoBadgePercentageResult.Type.BRANCH;
+import static com.github.dawnwords.jacoco.badge.JacocoBadgePercentageResult.Type.CLASS;
+import static com.github.dawnwords.jacoco.badge.JacocoBadgePercentageResult.Type.COMPLEXITY;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.stream.Collectors;
+
 import org.apache.commons.io.IOUtils;
 import org.gradle.internal.impldep.com.google.common.collect.ImmutableMap;
 import org.mockito.Mock;

--- a/src/test/java/com/github/dawnwords/jacoco/badge/ReadMeUpdaterTest.java
+++ b/src/test/java/com/github/dawnwords/jacoco/badge/ReadMeUpdaterTest.java
@@ -65,6 +65,7 @@ public class ReadMeUpdaterTest {
         + "![LINE](https://img.shields.io/badge/line--coverage-80%25-brightgreen.svg)\n"
         + "![BRANCH](branch-badge-url)\n"
         + "![COMPLEXITY](complexity-badge-url)\n"
+        + "Some ![COMPLEXITY](complexity-badge-url) inline consecutive ![BRANCH](branch-badge-url)![COMPLEXITY](complexity-badge-url) badges\n"
         + "\n"
         + "## some other description\n"
         + "blah blah blah blah blah blah");

--- a/src/test/resources/sample-readme.md
+++ b/src/test/resources/sample-readme.md
@@ -4,6 +4,7 @@
 ![LINE](https://img.shields.io/badge/line--coverage-80%25-brightgreen.svg)
 ![BRANCH](https://img.shields.io/badge/branch--coverage-70%25-yellow.svg)
 ![COMPLEXITY](https://img.shields.io/badge/complexity-2.3-red.svg)
+Some ![COMPLEXITY](X) inline consecutive ![BRANCH](X)![COMPLEXITY](X) badges
 
 ## some other description
 blah blah blah blah blah blah


### PR DESCRIPTION
This PR allows inline badges, e.g.:

```
Some ![BRANCH](X) inline ![COMPLEXITY](X) badges
```

- Implemented & tested inline badges parsing
- Updated locale-relying tests (which were failig in European-localised JVMs)
- Removed unused imports & warnings
- Expanded IDEs git-ignored files 