### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,20 @@ your code coverage on code change.
 plugins {
     id 'java'
     id 'jacoco'
-    id 'com.github.dawnwords.jacoco.badge'
+    id 'com.github.dawnwords.jacoco.badge' version '0.2.0'
+}
+```
+2. Add xml reports to jacoco task in `build.gradle`, for example:
+
+```groovy
+jacocoTestReport {
+  reports {
+    xml.enabled true 
+  }
 }
 ```
 
-2. Put the badge link placeholder in your `README.md`
+3. Put the badge link placeholder in your `README.md`
 
 ```markdown
 # Your Project Name


### PR DESCRIPTION
Add some necessary instructions to the README: Include version in plugin declaration, and requirement for xml reports to be generated by jacoco (since that is what the plugin reads to retrieve/calculate the coverage). I think the first one might only be a requirement of newer Gradle releases. Thanks for the cool software!!